### PR TITLE
fix divergence_exact's diagonal sum

### DIFF
--- a/run_nerf_helpers.py
+++ b/run_nerf_helpers.py
@@ -71,7 +71,7 @@ def compute_divergence_loss(
 def divergence_exact(input_points, offsets_of_inputs):
     # requires three backward passes instead one like divergence_approx
     jac = _get_minibatch_jacobian(offsets_of_inputs, input_points)
-    diagonal = jac.view(jac.shape[0], -1)[:, :: jac.shape[1]]
+    diagonal = jac.view(jac.shape[0], -1)[:, :: (jac.shape[1]+1)]
     return torch.sum(diagonal, 1)
 
 


### PR DESCRIPTION
In `run_nerf_helpers.py`: L71 `divergence_loss`, the original code to calculate the diagonal of jacobian matrix is wrong.

I'm guessing since it's using `divergence_approx` function by default, this error does not affect the default training behavior. 
But still it will affect the behavior when setting `exact=true` for training.

example:
```
jac[0,...]=
        [[  1.5425,   8.1350,   5.7477],
        [ -1.1500, -14.2937,  -9.5665],
        [ -0.5321,  11.8239,   5.3827]]

jac.view(jac.shape[0], -1)[0,...]=
         [  1.5425, 8.1350, 5.7477, -1.1500, -14.2937, -9.5665, -0.5321, 11.8239, 5.3827]

# wrong way
jac.view(jac.shape[0], -1)[0, :: jac.shape[1]]=
         [ 1.5425, -1.1500, -0.5321]

# correct way
jac.view(jac.shape[0], -1)[0, :: (jac.shape[1]+1)]=
         [  1.5425, -14.2937,   5.3827]
```